### PR TITLE
Sensor Overflow Logic fix

### DIFF
--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -261,7 +261,7 @@ class TSL2591:
             maxCounts = _TSL2591_MAX_COUNT
         
         # Handle overflow.
-        if channel_0 == maxCounts or channel_1 == maxCounts:
+        if channel_0 >= maxCounts or channel_1 >= maxCounts:
             raise RuntimeError('Overflow reading light channels!')
         # Calculate lux using same equation as Arduino library:
         #  https://github.com/adafruit/Adafruit_TSL2591_Library/blob/master/Adafruit_TSL2591.cpp

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -69,8 +69,8 @@ _TSL2591_LUX_DF              = 408.0
 _TSL2591_LUX_COEFB           = 1.64
 _TSL2591_LUX_COEFC           = 0.59
 _TSL2591_LUX_COEFD           = 0.86
-_TSL2591_MAX_COUNT_100MS     = const(36863)
-_TSL2591_MAX_COUNT           = const(65535)
+_TSL2591_MAX_COUNT_100MS     = const(36863) # 0x8FFF
+_TSL2591_MAX_COUNT           = const(65535) # 0xFFFF
 
 # User-facing constants:
 GAIN_LOW                  = 0x00  # low gain (1x)

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -70,7 +70,7 @@ _TSL2591_LUX_COEFB           = 1.64
 _TSL2591_LUX_COEFC           = 0.59
 _TSL2591_LUX_COEFD           = 0.86
 _TSL2591_MAX_COUNT_100MS     = const(36863)
-_TSL2591_MAX_COUNT           = const(0xFFFF)
+_TSL2591_MAX_COUNT           = const(65535)
 
 # User-facing constants:
 GAIN_LOW                  = 0x00  # low gain (1x)

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -250,18 +250,18 @@ class TSL2591:
         and visible light channels.
         """
         channel_0, channel_1 = self.raw_luminosity
-        
+
         # Compute the atime in milliseconds
         atime = 100.0 * self._integration_time + 100.0
-        
+
         # Set the maximum sensor counts based on the atime setting
-        if 100 == atime:
-            maxCounts = _TSL2591_MAX_COUNT_100MS
+        if atime == 100:
+            max_counts = _TSL2591_MAX_COUNT_100MS
         else:
-            maxCounts = _TSL2591_MAX_COUNT
-        
+            max_counts = _TSL2591_MAX_COUNT
+
         # Handle overflow.
-        if channel_0 >= maxCounts or channel_1 >= maxCounts:
+        if channel_0 >= max_counts or channel_1 >= max_counts:
             raise RuntimeError('Overflow reading light channels!')
         # Calculate lux using same equation as Arduino library:
         #  https://github.com/adafruit/Adafruit_TSL2591_Library/blob/master/Adafruit_TSL2591.cpp

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -248,8 +248,15 @@ class TSL2591:
         and visible light channels.
         """
         channel_0, channel_1 = self.raw_luminosity
+        
+        # Set the maximum sensor counts based on the atime setting
+        if 100 == atime:
+            maxCounts = 36863
+        else:
+            maxCounts = 0xFFFF
+        
         # Handle overflow.
-        if channel_0 == 0xFFFF or channel_1 == 0xFFFF:
+        if channel_0 == maxCounts or channel_1 == maxCounts:
             raise RuntimeError('Overflow reading light channels!')
         # Calculate lux using same equation as Arduino library:
         #  https://github.com/adafruit/Adafruit_TSL2591_Library/blob/master/Adafruit_TSL2591.cpp

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -254,8 +254,8 @@ class TSL2591:
         # Compute the atime in milliseconds
         atime = 100.0 * self._integration_time + 100.0
 
-        # Set the maximum sensor counts based on the atime setting
-        if atime == 100:
+        # Set the maximum sensor counts based on the integration time (atime) setting
+        if self._integration_time == INTEGRATIONTIME_100MS:
             max_counts = _TSL2591_MAX_COUNT_100MS
         else:
             max_counts = _TSL2591_MAX_COUNT

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -69,6 +69,8 @@ _TSL2591_LUX_DF              = 408.0
 _TSL2591_LUX_COEFB           = 1.64
 _TSL2591_LUX_COEFC           = 0.59
 _TSL2591_LUX_COEFD           = 0.86
+_TSL2591_MAX_COUNT_100MS     = const(36863)
+_TSL2591_MAX_COUNT           = const(0xFFFF)
 
 # User-facing constants:
 GAIN_LOW                  = 0x00  # low gain (1x)
@@ -249,18 +251,20 @@ class TSL2591:
         """
         channel_0, channel_1 = self.raw_luminosity
         
+        # Compute the atime in milliseconds
+        atime = 100.0 * self._integration_time + 100.0
+        
         # Set the maximum sensor counts based on the atime setting
         if 100 == atime:
-            maxCounts = 36863
+            maxCounts = _TSL2591_MAX_COUNT_100MS
         else:
-            maxCounts = 0xFFFF
+            maxCounts = _TSL2591_MAX_COUNT
         
         # Handle overflow.
         if channel_0 == maxCounts or channel_1 == maxCounts:
             raise RuntimeError('Overflow reading light channels!')
         # Calculate lux using same equation as Arduino library:
         #  https://github.com/adafruit/Adafruit_TSL2591_Library/blob/master/Adafruit_TSL2591.cpp
-        atime = 100.0 * self._integration_time + 100.0
         again = 1.0
         if self._gain == GAIN_MED:
             again = 25.0


### PR DESCRIPTION
Issue #5 fix by adding the maxCount and using a >= instead of just == check.

See Control Register (0x01) MaxCount for ATime of 100 ms to see the max count from the sensor is 36863