### PR TITLE
Added interrupt support

### DIFF
--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -192,8 +192,7 @@ class TSL2591:
         """Put the device in a powered, enabled mode."""
         self._write_u8(
             _TSL2591_REGISTER_ENABLE,
-            _TSL2591_ENABLE_POWERON
-            | _TSL2591_ENABLE_AEN,
+            _TSL2591_ENABLE_POWERON | _TSL2591_ENABLE_AEN,
         )
 
     def disable(self) -> None:
@@ -207,9 +206,10 @@ class TSL2591:
         - ``CLEAR_ALL_INTERRUPTS``
         - ``CLEAR_PERSIST_INTERRUPT``
         """
-        assert operation in (CLEAR_INTERRUPT,
-                             CLEAR_ALL_INTERRUPTS,
-                             CLEAR_PERSIST_INTERRUPT,
+        assert operation in (
+            CLEAR_INTERRUPT,
+            CLEAR_ALL_INTERRUPTS,
+            CLEAR_PERSIST_INTERRUPT,
         )
         control = (_TSL2591_SPECIAL_BIT | operation) & 0xFF
         with self._device as i2c:

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -218,9 +218,11 @@ class TSL2591:
 
     def enable_interrupt(self, interrupts: int) -> None:
         """Enable interrupts on device. ENABLE_NPIEN will turn on No Persist interrupts, these
-        bypass the persist filter and assert immediately. ENABLE_AIEN will assert after their
-        threshold values have exceeded the persist filter cycle constraints. The device powers
-        on with thresholds at 0, meaning enabling interrupts may cause an immediate assertion.
+        bypass the persist filter and assert immediately when values are detected above the high
+        threshold or below the low threshold. Similarly, ENABLE_AIEN will assert at the respective
+        ALS thresholds, but only after the values persist longer than the persist filter cycle
+        duration. The device powers on with thresholds at 0, meaning enabling interrupts may
+        cause an immediate assertion.
         Can be a value of:
         - ``ENABLE_NPIEN``
         - ``ENABLE_AIEN``
@@ -293,8 +295,8 @@ class TSL2591:
 
     @property
     def threshold_low(self) -> int:
-        """Get and set the ALS interrupt low threshold bytes. If the detected value exceeds
-        threshold for the number of persist cycles an interrupt will be triggered.
+        """Get and set the ALS interrupt low threshold bytes. If the detected value is below
+        the low threshold for the number of persist filter cycles an interrupt will be triggered.
         Can be 16-bit value."""
         th_low = self._read_u16LE(_TSL2591_AILTL)
         return th_low
@@ -308,8 +310,8 @@ class TSL2591:
 
     @property
     def threshold_high(self) -> int:
-        """Get and set the ALS interrupt high threshold bytes. If the detected value exceeds
-        threshold for the number of persist cycles an interrupt will be triggered.
+        """Get and set the ALS interrupt high threshold bytes. If the detected value is above
+        the high threshold for the number of persist filter cycles an interrupt will be triggered.
         Can be 16-bit value."""
         th_high = self._read_u16LE(_TSL2591_AIHTL)
         return th_high
@@ -324,7 +326,8 @@ class TSL2591:
     @property
     def nopersist_threshold_low(self) -> int:
         """Get and set the No Persist ALS low threshold bytes. An interrupt will be triggered
-        immediately once threshold is exceeded. Can be 16-bit value."""
+        immediately once the detected value is below the low threshold. Can be 16-bit value.
+        """
         np_th_low = self._read_u16LE(_TSL2591_NPAILTL)
         return np_th_low
 
@@ -338,7 +341,8 @@ class TSL2591:
     @property
     def nopersist_threshold_high(self) -> int:
         """Get and set the No Persist ALS high threshold bytes. An interrupt will be triggered
-        immediately once theshold is exceeded. Can be 16-bit value."""
+        immediately once the detected value is above the high threshold. Can be 16-bit value.
+        """
         np_th_high = self._read_u16LE(_TSL2591_NPAIHTL)
         return np_th_high
 
@@ -351,7 +355,7 @@ class TSL2591:
 
     @property
     def persist(self) -> int:
-        """Get and set the interrupt persistence filter - the number of consecutive out-of-range
+        """Get and set the interrupt persist filter - the number of consecutive out-of-range
         ALS cycles necessary to generate an interrupt."""
         persist = self._read_u8(_TSL2591_PERSIST_FILTER)
         return persist & 0x0F

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -302,9 +302,9 @@ class TSL2591:
         return th_low
 
     @threshold_low.setter
-    def threshold_low(self, value: int) -> None:
-        lower = value & 0xFF
-        upper = (value >> 8) & 0xFF
+    def threshold_low(self, val: int) -> None:
+        lower = val & 0xFF
+        upper = (val >> 8) & 0xFF
         self._write_u8(_TSL2591_AILTL, lower)
         self._write_u8(_TSL2591_AILTH, upper)
 
@@ -317,9 +317,9 @@ class TSL2591:
         return th_high
 
     @threshold_high.setter
-    def threshold_high(self, value: int) -> None:
-        lower = value & 0xFF
-        upper = (value >> 8) & 0xFF
+    def threshold_high(self, val: int) -> None:
+        lower = val & 0xFF
+        upper = (val >> 8) & 0xFF
         self._write_u8(_TSL2591_AIHTL, lower)
         self._write_u8(_TSL2591_AIHTH, upper)
 
@@ -332,9 +332,9 @@ class TSL2591:
         return np_th_low
 
     @nopersist_threshold_low.setter
-    def nopersist_threshold_low(self, value: int) -> None:
-        lower = value & 0xFF
-        upper = (value >> 8) & 0xFF
+    def nopersist_threshold_low(self, val: int) -> None:
+        lower = val & 0xFF
+        upper = (val >> 8) & 0xFF
         self._write_u8(_TSL2591_NPAILTL, lower)
         self._write_u8(_TSL2591_NPAILTH, upper)
 
@@ -347,22 +347,43 @@ class TSL2591:
         return np_th_high
 
     @nopersist_threshold_high.setter
-    def nopersist_threshold_high(self, value: int) -> None:
-        lower = value & 0xFF
-        upper = (value >> 8) & 0xFF
+    def nopersist_threshold_high(self, val: int) -> None:
+        lower = val & 0xFF
+        upper = (val >> 8) & 0xFF
         self._write_u8(_TSL2591_NPAIHTL, lower)
         self._write_u8(_TSL2591_NPAIHTH, upper)
 
     @property
     def persist(self) -> int:
         """Get and set the interrupt persist filter - the number of consecutive out-of-range
-        ALS cycles necessary to generate an interrupt."""
+        ALS cycles necessary to generate an interrupt. Valid persist values are 0 - 15 (inclusive),
+        corresponding to a preset number of cycles. Only the 4 lower bits will be used to write
+        to the device.
+        Can be a value of:
+        - ``0 (0000)`` - Every ALS cycle generates an interrupt.
+        - ``1 (0001)`` - Any value outside of threshold range.
+        - ``2 (0010)`` - 2 consecutive values out of range.
+        - ``3 (0011)`` - 3 consecutive values out of range.
+        - ``4 (0100)`` - 5 consecutive values out of range.
+        - ``5 (0101)`` - 10 consecutive values out of range.
+        - ``6 (0110)`` - 15 consecutive values out of range.
+        - ``7 (0111)`` - 20 consecutive values out of range.
+        - ``8 (1000)`` - 25 consecutive values out of range.
+        - ``9 (1001)`` - 30 consecutive values out of range.
+        - ``10 (1010)`` - 35 consecutive values out of range.
+        - ``11 (1011)`` - 40 consecutive values out of range.
+        - ``12 (1100)`` - 45 consecutive values out of range.
+        - ``13 (1101)`` - 50 consecutive values out of range.
+        - ``14 (1110)`` - 55 consecutive values out of range.
+        - ``15 (1111)`` - 60 consecutive values out of range.
+        """
         persist = self._read_u8(_TSL2591_PERSIST_FILTER)
         return persist & 0x0F
 
     @persist.setter
-    def persist(self, value: int) -> None:
-        persist = value & 0x0F
+    def persist(self, val: int) -> None:
+        assert 0 <= val <= 15
+        persist = val & 0x0F
         self._write_u8(_TSL2591_PERSIST_FILTER, persist)
 
     @property


### PR DESCRIPTION
Remove NPIEN and AIEN from enable command.
Made separate control functions for enabling interrupts. Exposed new variables for setting enabled functions.

Added persist, no persist threshold high and low, and ALS threshold high and low properties for setting boundaries.

Interrupts are off by default so users have a chance to set thresholds and persist values before they receive an interrupt. Otherwise, with thesholds at 0 interrupts always fire until set or cleared. When both are enabled users can see unexpected interrupts if only one style is expected but both are on.

Tested on Raspberry Pi 5.

Closes #29 