### PR TITLE
Fixing visible, infrared, and full_spectrum functions

### DIFF
--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -399,8 +399,7 @@ class TSL2591:
         """Read the full spectrum (IR + visible) light and return its value
         as a 16-bit unsigned number.
         """
-        channel_0, _ = self.raw_luminosity
-        return channel_0
+        return self.raw_luminosity[0]
 
     @property
     def infrared(self) -> int:

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -412,8 +412,7 @@ class TSL2591:
     def visible(self) -> int:
         """Read the visible light and return its value as a 16-bit unsigned number."""
         channel_0, channel_1 = self.raw_luminosity
-        full = channel_0
-        return full - channel_1
+        return channel_0 - channel_1
 
     @property
     def lux(self) -> float:

--- a/adafruit_tsl2591.py
+++ b/adafruit_tsl2591.py
@@ -397,10 +397,10 @@ class TSL2591:
     @property
     def full_spectrum(self) -> int:
         """Read the full spectrum (IR + visible) light and return its value
-        as a 32-bit unsigned number.
+        as a 16-bit unsigned number.
         """
-        channel_0, channel_1 = self.raw_luminosity
-        return (channel_1 << 16) | channel_0
+        channel_0, _ = self.raw_luminosity
+        return channel_0
 
     @property
     def infrared(self) -> int:
@@ -410,9 +410,9 @@ class TSL2591:
 
     @property
     def visible(self) -> int:
-        """Read the visible light and return its value as a 32-bit unsigned number."""
+        """Read the visible light and return its value as a 16-bit unsigned number."""
         channel_0, channel_1 = self.raw_luminosity
-        full = (channel_1 << 16) | channel_0
+        full = channel_0
         return full - channel_1
 
     @property


### PR DESCRIPTION
The logic for the visible and full_spectrum functions seems to be currently based off the [C++ version of the TSL2591 library](https://github.com/adafruit/Adafruit_TSL2591_Library/blob/master/Adafruit_TSL2591.cpp). 

This reads the 16 bit values from channels 0 and 1 (Vis+IR and IR respectively) and bit shifts the IR value left by 16 to return a uint_32 containing both, to be processed back into uint_16s in the vis, IR, and full spectrum functions.

In circuitpython as we can return a tuple of both channel values, we don't need to do any bit shifting. However, the current code performs a bit shift on the channel 1 value, and bitwise OR against channel 0:
``` python
@property
def full_spectrum(self) -> int:
    """Read the full spectrum (IR + visible) light and return its value
    as a 32-bit unsigned number.
    """
    channel_0, channel_1 = self.raw_luminosity
    return (channel_1 << 16) | channel_0
```

and:
```python
@property
def visible(self) -> int:
    """Read the visible light and return its value as a 32-bit unsigned number."""
    channel_0, channel_1 = self.raw_luminosity
    full = (channel_1 << 16) | channel_0
    return full - channel_1
```

As the values were not originally bit shifted, this means that `full_spectrum()` returns
$l_{fs}\times2^{16}$

and `visible()` returns 
$l_{fs}\times2^{16} - l_{ir}$

where $l_{fs}$ and $l_{ir}$ are the channel 0 full spectrum and channel 1 IR values respectively.

The `infrared()` function correctly just returns channel 1.

The upshot is that the IR value is on a scale several orders of magnitude smaller than Vis+IR and subtracting them therefore returns a nonsensical number.

This fix removes the bitwise manipulation and just returns channel 0, channel 1, and channel 0 - channel 1 respectively for full spectrum, IR, and visible.

It would not affect the `lux()` function which just uses the raw channel values.
